### PR TITLE
improve __getitem__

### DIFF
--- a/tests/test_timeseriesx.py
+++ b/tests/test_timeseriesx.py
@@ -795,6 +795,18 @@ def test_get_item_positional_index(default_timestamp_series):
     assert default_timestamp_series[0] == 0 * ureg.Unit('m')
 
 
+def test_get_item_positional_slice_index(default_timestamp_series):
+    result_ts = default_timestamp_series[:2]
+    assert result_ts.timestamps == default_timestamp_series.timestamps[:2]
+    assert result_ts.values == default_timestamp_series.values[:2]
+
+
+def test_get_item_positional_list_index(default_timestamp_series):
+    result_ts = default_timestamp_series[[0, 1]]
+    assert result_ts.timestamps == default_timestamp_series.timestamps[:2]
+    assert result_ts.values == default_timestamp_series.values[:2]
+
+
 def test_get_item_datetime_index(default_timestamp_series):
     assert default_timestamp_series[default_timestamp_series.start] == 0 * ureg.Unit('m')
 
@@ -802,6 +814,12 @@ def test_get_item_datetime_index(default_timestamp_series):
 def test_get_item_naive_datetime_index(default_timestamp_series):
     assert default_timestamp_series[
                default_timestamp_series.start.replace(tzinfo=None)] == 0 * ureg.Unit('m')
+
+
+def test_get_item_datetime_list_index(default_timestamp_series):
+    result_ts = default_timestamp_series[default_timestamp_series.timestamps[:2]]
+    assert result_ts.timestamps == default_timestamp_series.timestamps[:2]
+    assert result_ts.values == default_timestamp_series.values[:2]
 
 
 def test_loop(default_timestamp_series):

--- a/timeseriesx/base/base_time_series.py
+++ b/timeseriesx/base/base_time_series.py
@@ -1,5 +1,6 @@
 import copy
 from abc import ABCMeta, abstractmethod
+from collections.abc import Iterable
 
 import numpy as np
 
@@ -84,12 +85,7 @@ class BaseTimeSeries(metaclass=ABCMeta):
     # ---------------------------- magic methods ----------------------------- #
 
     def __getitem__(self, item):
-        if isinstance(item, slice):
-            new_ts = copy.deepcopy(self)
-            new_ts._series = new_ts._series[item]
-            return new_ts
-        else:
-            return self._series[item]
+        return NotImplemented()
 
     def __setitem__(self, key, value):
         return NotImplemented()

--- a/timeseriesx/base/timestamp_series.py
+++ b/timeseriesx/base/timestamp_series.py
@@ -1,21 +1,23 @@
 import collections
 import copy
+import datetime as dt
 import numbers
 import warnings
+from collections.abc import Iterable
 
 import numpy as np
 import pandas as pd
 from pint import Quantity
 from pint_pandas import PintArray, PintType
 
-from timeseriesx.validation.timestamp_index import (
-    index_is_datetime,
-    index_is_sorted,
-)
 from timeseriesx.base.base_time_series import BaseTimeSeries
 from timeseriesx.mixins.frequency import FrequencyMixin
 from timeseriesx.mixins.time_zone import TimeZoneMixin
 from timeseriesx.mixins.unit import UnitMixin
+from timeseriesx.validation.timestamp_index import (
+    index_is_datetime,
+    index_is_sorted,
+)
 
 
 class TimestampSeries(UnitMixin, TimeZoneMixin, FrequencyMixin, BaseTimeSeries):
@@ -387,6 +389,16 @@ class TimestampSeries(UnitMixin, TimeZoneMixin, FrequencyMixin, BaseTimeSeries):
             other_timestamps = tmp_other.timestamps
 
         return self_timestamps == other_timestamps and self_values == other_values
+
+    def __getitem__(self, item):
+        if isinstance(item, (slice, Iterable)):
+            new_ts = copy.deepcopy(self)
+            new_ts._series = new_ts._series[item]
+            return new_ts
+        else:
+            if isinstance(item, dt.datetime) and item.tzinfo is None and self.time_zone is not None:
+                item = self.time_zone.localize(item)
+            return self._series[item]
 
     def __setitem__(self, key, value):
         raise NotImplementedError()

--- a/timeseriesx/base/timestamp_series.py
+++ b/timeseriesx/base/timestamp_series.py
@@ -396,7 +396,8 @@ class TimestampSeries(UnitMixin, TimeZoneMixin, FrequencyMixin, BaseTimeSeries):
             new_ts._series = new_ts._series[item]
             return new_ts
         else:
-            if isinstance(item, dt.datetime) and item.tzinfo is None and self.time_zone is not None:
+            if isinstance(item, dt.datetime) and item.tzinfo is None \
+                    and self.time_zone is not None:
                 item = self.time_zone.localize(item)
             return self._series[item]
 


### PR DESCRIPTION
extend getitem functionality by supporting iterables of timestamps or positional indices
explicitly support indexing by time zone naive timestamps, which is deprecated by pandas