### PR TITLE
Coerce unit optionally

### DIFF
--- a/timeseriesx/mixins/unit.py
+++ b/timeseriesx/mixins/unit.py
@@ -16,8 +16,6 @@ class UnitMixin(BaseMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._unit = kwargs.get("unit", None)
-        if self._unit:
-            self._unit = coerce_unit(self._unit)
         self._validate_unit()
 
     @property
@@ -104,7 +102,7 @@ class UnitMixin(BaseMixin):
         return self
 
     def _validate_unit(self):
-        coerce_unit(self._unit)
+        self._unit = coerce_unit(self._unit)
         if isinstance(self._series.dtype, PintType):
             if self._series.pint.u != self._unit:
                 try:

--- a/timeseriesx/validation/unit.py
+++ b/timeseriesx/validation/unit.py
@@ -11,6 +11,8 @@ def coerce_unit(unit):
     :return: the coerced unit
     :rtype: pint.Unit
     """
+    if unit is None:
+        return unit
     if isinstance(unit, str):
         unit = ureg.parse_units(unit)
     if isinstance(unit, Unit):


### PR DESCRIPTION
Make `coerce_unit` behave like `coerce_freq` and `coerce_time_zone` by passing through `None`. Also make `_validate_unit` behave like `_validate_freq` and `_validate_time_zone` by actually setting `self._unit` instead of only checking it.