### PR TITLE
rename factory methods

### DIFF
--- a/tests/test_timeseriesx.py
+++ b/tests/test_timeseriesx.py
@@ -32,11 +32,11 @@ def default_timestamp_series(n=3):
     )
 
 
-def test_timestamp_series_create_null_timeseries():
+def test_timestamp_series_create_null_series():
     start = pd.Timestamp(2020, 3, 1, 15, 0, 0).tz_localize('UTC').to_pydatetime()
     end = pd.Timestamp(2020, 3, 1, 17, 0, 0).tz_localize('UTC').to_pydatetime()
     freq = '1H'
-    ts = TimestampSeries.create_null_timeseries(start, end, freq)
+    ts = TimestampSeries.create_null_series(start, end, freq)
     assert ts.freq == pd.offsets.Hour()
     assert ts.time_zone is pytz.UTC
     assert ts.unit is None

--- a/timeseriesx/base/timestamp_series.py
+++ b/timeseriesx/base/timestamp_series.py
@@ -50,7 +50,7 @@ class TimestampSeries(UnitMixin, TimeZoneMixin, FrequencyMixin, BaseTimeSeries):
         :return: a new TimestampSeries-object
         :rtype: TimestampSeries
         """
-        warnings.warn("this method was renamed, and will be deprecated in a future "
+        warnings.warn("this method was renamed, and will be removed in a future "
                       "version, please use `create_null_series` instead",
                       category=DeprecationWarning)
         return TimestampSeries.create_null_series(start, end, freq, unit=unit,
@@ -103,7 +103,7 @@ class TimestampSeries(UnitMixin, TimeZoneMixin, FrequencyMixin, BaseTimeSeries):
         :return: a new TimestampSeries-object
         :rtype: TimestampSeries
         """
-        warnings.warn("this method was renamed, and will be deprecated in a future "
+        warnings.warn("this method was renamed, and will be removed in a future "
                       "version, please use `create_constant_series` instead",
                       category=DeprecationWarning)
         return TimestampSeries.create_constant_series(start, end, value, freq,

--- a/timeseriesx/base/timestamp_series.py
+++ b/timeseriesx/base/timestamp_series.py
@@ -50,12 +50,67 @@ class TimestampSeries(UnitMixin, TimeZoneMixin, FrequencyMixin, BaseTimeSeries):
         :return: a new TimestampSeries-object
         :rtype: TimestampSeries
         """
-        return TimestampSeries.create_constant_timeseries(
+        warnings.warn("this method was renamed, and will be deprecated in a future "
+                      "version, please use `create_null_series` instead",
+                      category=DeprecationWarning)
+        return TimestampSeries.create_null_series(start, end, freq, unit=unit,
+                                                  time_zone=time_zone)
+
+    @staticmethod
+    def create_null_series(start, end, freq, unit=None, time_zone='infer'):
+        """
+        create a `TimestampSeries`-object from `start` to `end` with NaN-values
+
+        :param str/datetime.datetime/pandas.Timestamp start: the start timestamp of the
+            series (included)
+        :param str/datetime.datetime/pandas.Timestamp end: the end timestamp of the
+            series (included)
+        :param str/datetime.timedelta/pandas.Offset/pandas.Timedelta freq:
+            the frequency of the timestamp series, `pandas offset aliases <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases>`_
+            supported
+        :param str/pint.Unit unit: the unit of the series's values, many string
+            representations of common units are supported, such as `m`, `s`, `kg`
+            and many more
+        :param str/tzinfo time_zone: the name of the time zone, (see `IANA <https://www.iana.org/time-zones>`_)
+            or a tzinfo-object, pass `'infer'` if you want the time zone to be derived
+            from `start` and `end`
+        :return: a new TimestampSeries-object
+        :rtype: TimestampSeries
+        """
+        return TimestampSeries.create_constant_series(
             start, end, np.NaN, freq, unit, time_zone=time_zone)
 
     @staticmethod
     def create_constant_timeseries(start, end, value, freq, unit=None,
                                    time_zone='infer'):
+        """
+        create a `TimestampSeries`-object from `start` to `end` with constant value
+
+        :param str/datetime.datetime/pandas.Timestamp start: the start timestamp of the
+            series (included)
+        :param str/datetime.datetime/pandas.Timestamp end: the end timestamp of the
+            series (included)
+        :param int/float value: the constant value for each element
+        :param str/datetime.timedelta/pandas.Offset/pandas.Timedelta freq:
+            the frequency of the timestamp series, `pandas offset aliases <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases>`_
+            supported
+        :param str/pint.Unit unit: the unit of the series's values, many string
+            representations of common units are supported, such as `m`, `s`, `kg`
+            and many more
+        :param str/tzinfo time_zone: the name of the time zone, (see `IANA <https://www.iana.org/time-zones>`_)
+            or a tzinfo-object, pass `'infer'` if you want the time zone to be derived
+            from `start` and `end`
+        :return: a new TimestampSeries-object
+        :rtype: TimestampSeries
+        """
+        warnings.warn("this method was renamed, and will be deprecated in a future "
+                      "version, please use `create_constant_series` instead",
+                      category=DeprecationWarning)
+        return TimestampSeries.create_constant_series(start, end, value, freq,
+                                                      unit=unit, time_zone=time_zone)
+
+    @staticmethod
+    def create_constant_series(start, end, value, freq, unit=None, time_zone='infer'):
         """
         create a `TimestampSeries`-object from `start` to `end` with constant value
 

--- a/timeseriesx/base/timestamp_series.py
+++ b/timeseriesx/base/timestamp_series.py
@@ -29,8 +29,8 @@ class TimestampMismatchWarning(RuntimeWarning):
 
 class TimestampSeries(UnitMixin, TimeZoneMixin, FrequencyMixin, BaseTimeSeries):
 
-    @staticmethod
-    def create_null_timeseries(start, end, freq, unit=None, time_zone='infer'):
+    @classmethod
+    def create_null_timeseries(cls, start, end, freq, unit=None, time_zone='infer'):
         """
         create a `TimestampSeries`-object from `start` to `end` with NaN-values
 
@@ -56,8 +56,8 @@ class TimestampSeries(UnitMixin, TimeZoneMixin, FrequencyMixin, BaseTimeSeries):
         return TimestampSeries.create_null_series(start, end, freq, unit=unit,
                                                   time_zone=time_zone)
 
-    @staticmethod
-    def create_null_series(start, end, freq, unit=None, time_zone='infer'):
+    @classmethod
+    def create_null_series(cls, start, end, freq, unit=None, time_zone='infer'):
         """
         create a `TimestampSeries`-object from `start` to `end` with NaN-values
 
@@ -77,11 +77,11 @@ class TimestampSeries(UnitMixin, TimeZoneMixin, FrequencyMixin, BaseTimeSeries):
         :return: a new TimestampSeries-object
         :rtype: TimestampSeries
         """
-        return TimestampSeries.create_constant_series(
-            start, end, np.NaN, freq, unit, time_zone=time_zone)
+        return cls.create_constant_series(start, end, np.NaN, freq, unit=unit,
+                                          time_zone=time_zone)
 
-    @staticmethod
-    def create_constant_timeseries(start, end, value, freq, unit=None,
+    @classmethod
+    def create_constant_timeseries(cls, start, end, value, freq, unit=None,
                                    time_zone='infer'):
         """
         create a `TimestampSeries`-object from `start` to `end` with constant value
@@ -106,11 +106,12 @@ class TimestampSeries(UnitMixin, TimeZoneMixin, FrequencyMixin, BaseTimeSeries):
         warnings.warn("this method was renamed, and will be removed in a future "
                       "version, please use `create_constant_series` instead",
                       category=DeprecationWarning)
-        return TimestampSeries.create_constant_series(start, end, value, freq,
-                                                      unit=unit, time_zone=time_zone)
+        return cls.create_constant_series(start, end, value, freq,
+                                          unit=unit, time_zone=time_zone)
 
-    @staticmethod
-    def create_constant_series(start, end, value, freq, unit=None, time_zone='infer'):
+    @classmethod
+    def create_constant_series(cls, start, end, value, freq, unit=None,
+                               time_zone='infer'):
         """
         create a `TimestampSeries`-object from `start` to `end` with constant value
 
@@ -133,11 +134,11 @@ class TimestampSeries(UnitMixin, TimeZoneMixin, FrequencyMixin, BaseTimeSeries):
         """
         index = pd.date_range(start, end, freq=freq)
         series = pd.Series([value] * len(index), index=index)
-        return TimestampSeries.create_from_pd_series(series, freq=freq, unit=unit,
-                                                     time_zone=time_zone)
+        return cls.create_from_pd_series(series, freq=freq, unit=unit,
+                                         time_zone=time_zone)
 
-    @staticmethod
-    def create_from_lists(timestamps, values, freq='infer', unit=None,
+    @classmethod
+    def create_from_lists(cls, timestamps, values, freq='infer', unit=None,
                           time_zone='infer'):
         """
         create a `TimestampSeries`-object from a list of timestamps and values matched
@@ -161,11 +162,11 @@ class TimestampSeries(UnitMixin, TimeZoneMixin, FrequencyMixin, BaseTimeSeries):
         if not len(timestamps) == len(values):
             raise ValueError('lengths of timestamps and values do not not match')
         tuples = list(zip(timestamps, values))
-        return TimestampSeries.create_from_tuples(tuples, freq=freq, unit=unit,
-                                                  time_zone=time_zone)
+        return cls.create_from_tuples(tuples, freq=freq, unit=unit,
+                                      time_zone=time_zone)
 
-    @staticmethod
-    def create_from_tuples(tuples, freq='infer', unit=None, time_zone='infer'):
+    @classmethod
+    def create_from_tuples(cls, tuples, freq='infer', unit=None, time_zone='infer'):
         """
         create a `TimestampSeries`-object from a list of tuples of timestamps and values
 
@@ -184,11 +185,11 @@ class TimestampSeries(UnitMixin, TimeZoneMixin, FrequencyMixin, BaseTimeSeries):
         :rtype: TimestampSeries
         """
         dictionary = {k: v for k, v in tuples}
-        return TimestampSeries.create_from_dict(dictionary, freq=freq, unit=unit,
-                                                time_zone=time_zone)
+        return cls.create_from_dict(dictionary, freq=freq, unit=unit,
+                                    time_zone=time_zone)
 
-    @staticmethod
-    def create_from_dict(dictionary, freq='infer', unit=None, time_zone='infer'):
+    @classmethod
+    def create_from_dict(cls, dictionary, freq='infer', unit=None, time_zone='infer'):
         """
         create a `TimestampSeries`-object from a dict timestamps as keys and values as
         values
@@ -209,11 +210,11 @@ class TimestampSeries(UnitMixin, TimeZoneMixin, FrequencyMixin, BaseTimeSeries):
         :rtype: TimestampSeries
         """
         series = pd.Series(dictionary)
-        return TimestampSeries.create_from_pd_series(series, freq=freq, unit=unit,
-                                                     time_zone=time_zone)
+        return cls.create_from_pd_series(series, freq=freq, unit=unit,
+                                         time_zone=time_zone)
 
-    @staticmethod
-    def create_from_pd_series(series, freq='infer', unit=None, time_zone='infer'):
+    @classmethod
+    def create_from_pd_series(cls, series, freq='infer', unit=None, time_zone='infer'):
         """
         create a `TimestampSeries`-object from a pandas `Series` with `DatetimeIndex`
 
@@ -231,7 +232,7 @@ class TimestampSeries(UnitMixin, TimeZoneMixin, FrequencyMixin, BaseTimeSeries):
         :return: a new TimestampSeries-object
         :rtype: TimestampSeries
         """
-        return TimestampSeries(series, freq=freq, unit=unit, time_zone=time_zone)
+        return cls(series, freq=freq, unit=unit, time_zone=time_zone)
 
     # ------------------------------ constructor ----------------------------- #
 


### PR DESCRIPTION
deprecate `TimestampSeries.create_null_timeseries` and `TimestampSeries.create_constant_timeseries`, rename to
`TimestampSeries.create_null_series` and `TimestampSeries.create_constant_series`.

motivation:
the created series is a *Timestamp-Series*, a *Time-Series* and a *Series*. The most explicit name would be `create_constant_timestampseries`. Since this is already provided by the namespace of the class, I'd go for the most generic version, which is *Series*.